### PR TITLE
fix: remove non-existent folders from list (RDT-1413)

### DIFF
--- a/idf_ci/utils.py
+++ b/idf_ci/utils.py
@@ -75,7 +75,7 @@ def remove_subfolders(paths: t.List[str]) -> t.List[str]:
         if not any(parent in result for parent in p.parents):
             result.add(p)
 
-    return sorted([str(p) for p in result])
+    return sorted([str(p) for p in result if p.is_dir()])
 
 
 def get_current_branch() -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,12 +9,18 @@ from idf_ci.utils import remove_subfolders
 
 
 @pytest.mark.parametrize(
-    'paths,expected',
+    'relpaths,expected_relpaths',
     [
-        (['/a/b/c', '/a/b', '/a', '/a/b/c/d'], ['/a']),
-        (['/b', '/a/b', '/a', '/c/d'], ['/a', '/b', '/c/d']),
+        (['a/b/c', 'a/b', 'a', 'a/b/c/d'], ['a']),
+        (['b', 'a/b', 'a', 'c/d'], ['a', 'b', 'c/d']),
     ],
 )
 @pytest.mark.skipif(sys.platform == 'win32', reason='Using Unix paths')
-def test_remove_subfolders(paths, expected):
+def test_remove_subfolders(tmp_path, relpaths, expected_relpaths):
+    paths = []
+    for rel in relpaths:
+        dir_path = tmp_path / rel
+        dir_path.mkdir(parents=True, exist_ok=True)
+        paths.append(str(dir_path))
+    expected = [str(tmp_path / rel) for rel in expected_relpaths]
     assert remove_subfolders(paths) == expected


### PR DESCRIPTION


## Description

There is a issue with non-existent folders. For example, when a folder is removed, it might still appear in the list. Then, pytest runs with arguments that include this folder. Since the folder no longer exists, pytest will fail.

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
