### PR TITLE
feat: component targets (CII-178)

### DIFF
--- a/idf_ci/filters/__init__.py
+++ b/idf_ci/filters/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0

--- a/idf_ci/filters/component_targets.py
+++ b/idf_ci/filters/component_targets.py
@@ -2,26 +2,53 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 import re
 from functools import lru_cache
-from typing import Dict, Iterable, List, Optional, Set
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
-from esp_bool_parser.constants import ALL_TARGETS
+from idf_ci.settings import get_ci_settings
 
 logger = logging.getLogger(__name__)
 
-TARGET_PATTERN = re.compile(r'(?<![a-z0-9])(' + '|'.join(sorted(ALL_TARGETS, key=len, reverse=True)) + r')(?![a-z0-9])')
+
+def _normalized_path(path: str) -> str:
+    raw_path = Path(path)
+    if not raw_path.is_absolute():
+        return raw_path.as_posix()
+
+    settings = get_ci_settings()
+    abs_path = raw_path.as_posix()
+
+    try:
+        return Path(abs_path).relative_to(settings.project_root).as_posix()
+    except ValueError:
+        return abs_path
 
 
-def component_for_path(path: str) -> Optional[str]:
-    parts = [part for part in path.split('/') if part]
-    if len(parts) < 2 or parts[0] != 'components':
-        return None
-    return parts[1]
+def _component_mapping_search_path(path: str) -> str:
+    search_path = path if path.startswith('/') else f'/{path}'
+    return f'{search_path.rstrip("/")}/'
 
 
-def component_root(component: str) -> str:
-    return f'components/{component}'
+def _component_mapping_for_path(path: str) -> Optional[Tuple[str, str, str]]:
+    settings = get_ci_settings()
+    normalized_path = _normalized_path(path)
+    candidate = _component_mapping_search_path(normalized_path)
+
+    for regex in settings.all_component_mapping_regexes:
+        match = regex.search(candidate)
+        if not match:
+            continue
+
+        root = candidate[: match.end()].rstrip('/')
+        if not normalized_path.startswith('/'):
+            root = root.lstrip('/')
+
+        return match.group(1), root, normalized_path
+
+    return None
 
 
 def folder_for_path(path: str) -> str:
@@ -40,7 +67,19 @@ def collapse_folders(folders: Iterable[str]) -> List[str]:
 
 
 def extract_targets(path: str) -> Set[str]:
-    return set(TARGET_PATTERN.findall(path))
+    settings = get_ci_settings()
+    candidates = [path]
+    if not path.endswith('/'):
+        candidates.append(f'{path}/')
+
+    found_targets: Set[str] = set()
+    for candidate in candidates:
+        for regex in settings.all_component_target_regexes:
+            overlapping_regex = re.compile(f'(?={regex.pattern})', regex.flags)
+            for match in overlapping_regex.findall(candidate):
+                found_targets.add(match[0] if isinstance(match, tuple) else match)
+
+    return found_targets
 
 
 def targets_for_folders(folders: List[str]) -> List[str]:
@@ -53,6 +92,13 @@ def targets_for_folders(folders: List[str]) -> List[str]:
         found_targets.update(folder_targets)
 
     return sorted(found_targets)
+
+
+def _is_path_excluded(path: str) -> bool:
+    abs_path = Path(os.path.abspath(path)).as_posix()
+    settings = get_ci_settings()
+
+    return any(regex.search(abs_path) for regex in settings.all_component_mapping_exclude_regexes)
 
 
 @lru_cache()
@@ -69,12 +115,16 @@ def component_targets_from_files(
         if not path:
             continue
 
-        component = component_for_path(path)
-        if component is None:
+        if _is_path_excluded(path):
+            logger.debug('Skipping excluded path for component mapping: %s', path)
             continue
 
-        folder = folder_for_path(path)
-        root = component_root(component)
+        component_mapping = _component_mapping_for_path(path)
+        if component_mapping is None:
+            continue
+
+        component, root, normalized_path = component_mapping
+        folder = folder_for_path(normalized_path)
         if not folder.startswith(root):
             folder = root
 

--- a/idf_ci/filters/component_targets.py
+++ b/idf_ci/filters/component_targets.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import re
+from functools import lru_cache
+from typing import Dict, Iterable, List, Optional, Set
+
+from esp_bool_parser.constants import ALL_TARGETS
+
+logger = logging.getLogger(__name__)
+
+TARGET_PATTERN = re.compile(r'(?<![a-z0-9])(' + '|'.join(sorted(ALL_TARGETS, key=len, reverse=True)) + r')(?![a-z0-9])')
+
+
+def component_for_path(path: str) -> Optional[str]:
+    parts = [part for part in path.split('/') if part]
+    if len(parts) < 2 or parts[0] != 'components':
+        return None
+    return parts[1]
+
+
+def component_root(component: str) -> str:
+    return f'components/{component}'
+
+
+def folder_for_path(path: str) -> str:
+    return path.rsplit('/', 1)[0] if '/' in path else path
+
+
+def collapse_folders(folders: Iterable[str]) -> List[str]:
+    collapsed: List[str] = []
+
+    for folder in sorted(set(folders), key=lambda item: (item.count('/'), item)):
+        if any(folder == root or folder.startswith(root + '/') for root in collapsed):
+            continue
+        collapsed.append(folder)
+
+    return collapsed
+
+
+def extract_targets(path: str) -> Set[str]:
+    return set(TARGET_PATTERN.findall(path))
+
+
+def targets_for_folders(folders: List[str]) -> List[str]:
+    found_targets: Set[str] = set()
+
+    for folder in folders:
+        folder_targets = extract_targets(folder)
+        if not folder_targets:
+            return ['all']
+        found_targets.update(folder_targets)
+
+    return sorted(found_targets)
+
+
+@lru_cache()
+def component_targets_from_files(
+    modified_files: Iterable[str],
+) -> Dict[str, List[str]]:
+    component_groups: Dict[str, Set[str]] = {}
+
+    for path in modified_files:
+        if not isinstance(path, str):
+            continue
+
+        path = path.strip()
+        if not path:
+            continue
+
+        component = component_for_path(path)
+        if component is None:
+            continue
+
+        folder = folder_for_path(path)
+        root = component_root(component)
+        if not folder.startswith(root):
+            folder = root
+
+        component_groups.setdefault(component, set()).add(folder)
+
+    res = {
+        component: targets_for_folders(collapse_folders(component_folders))
+        for component, component_folders in sorted(component_groups.items())
+    }
+    logger.debug(
+        'Modified files %s: component → target mapping: %s',
+        modified_files,
+        res,
+    )
+    return res
+
+
+def combined_targets_for_components(
+    modified_files: Iterable[str],
+    check_components: Iterable[str],
+) -> List[str]:
+    component_targets = component_targets_from_files(tuple(modified_files))
+    combined_targets: Set[str] = set()
+    if not check_components:
+        for k in component_targets:
+            targets = component_targets.get(k)
+            if not targets:
+                continue
+            if targets == ['all']:
+                return ['all']
+            combined_targets.update(targets)
+
+    for component in check_components:
+        targets = component_targets.get(component)
+        if not targets:
+            continue
+        if targets == ['all']:
+            return ['all']
+        combined_targets.update(targets)
+
+    return sorted(combined_targets)
+
+
+def should_skip_build_for_components(
+    modified_files: Iterable[str],
+    check_components: Iterable[str],
+    current_target: str,
+) -> bool:
+    targets = combined_targets_for_components(modified_files, check_components)
+    should_skip = bool(targets) and 'all' not in targets and current_target not in targets
+    return should_skip

--- a/idf_ci/scripts.py
+++ b/idf_ci/scripts.py
@@ -13,6 +13,7 @@ from idf_build_apps.utils import get_parallel_start_stop
 
 from ._compat import UNDEF, UndefinedOr, is_defined_and_satisfies, is_undefined
 from .envs import GitlabEnvVars
+from .filters.component_targets import should_skip_build_for_components
 from .settings import get_ci_settings
 
 if t.TYPE_CHECKING:
@@ -54,6 +55,39 @@ def _filter_apps_by_modified_files(
             current = os.path.dirname(current)
 
     return [app for app in apps if os.path.abspath(app.app_dir) in modified_app_dirs]
+
+
+def _filter_apps_by_component_target(
+    apps: t.Iterable['App'],
+    modified_files: t.Sequence[str],
+):
+    # test_apps should build all targets for this component,
+    # but when determining whether this target affects other apps,
+    # we should exclude it.
+    modified_files = [f for f in modified_files if '/test_apps' in f]
+
+    app_list: t.List[App] = list(apps)
+    logger.debug(
+        'Number of apps before component-target filter: %d',
+        len(app_list),
+    )
+
+    filtered_apps = {
+        _app
+        for _app in app_list
+        if not should_skip_build_for_components(
+            modified_files,
+            _app.depends_components,
+            _app.target,
+        )
+    }
+
+    logger.debug(
+        'Number of apps after component-target filter: %d',
+        len(filtered_apps),
+    )
+
+    return filtered_apps
 
 
 @dataclass
@@ -310,6 +344,17 @@ def get_all_apps(
     if _select_by_targets:
         # no need to remove test_apps, since they are not in non_test_apps
         non_test_apps = {app for app in non_test_apps if app.target in _select_by_targets}
+
+    if (
+        settings.filter_apps_by_component_target
+        and processed_args.modified_files
+        and os.getenv('CI_MERGE_REQUEST_IID') is not None
+    ):
+        # Build all targets apps for modified folders
+        full_target_apps = set(_filter_apps_by_modified_files(test_apps, processed_args.modified_files))
+        # Skip non target-related apps
+        filtered_apps = _filter_apps_by_component_target(test_apps, processed_args.modified_files)
+        test_apps = filtered_apps.union(full_target_apps)
 
     test_apps = test_apps.union(modified_test_apps)
     for app in test_apps:

--- a/idf_ci/scripts.py
+++ b/idf_ci/scripts.py
@@ -61,11 +61,6 @@ def _filter_apps_by_component_target(
     apps: t.Iterable['App'],
     modified_files: t.Sequence[str],
 ):
-    # test_apps should build all targets for this component,
-    # but when determining whether this target affects other apps,
-    # we should exclude it.
-    modified_files = [f for f in modified_files if '/test_apps' in f]
-
     app_list: t.List[App] = list(apps)
     logger.debug(
         'Number of apps before component-target filter: %d',

--- a/idf_ci/settings.py
+++ b/idf_ci/settings.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping
 from contextvars import ContextVar
 from pathlib import Path
 
+from esp_bool_parser.constants import ALL_TARGETS
 from idf_build_apps import App, json_list_files_to_apps
 from idf_build_apps.constants import BuildStatus
 from pydantic import BaseModel, model_validator
@@ -526,6 +527,14 @@ class CiSettings(BaseSettings):
     ]
     """List of regex patterns to exclude certain paths from component mapping."""
 
+    component_target_regexes: t.List[str] = [
+        r'(?<![a-z0-9])(' + '|'.join(sorted(ALL_TARGETS, key=len, reverse=True)) + r')(?![a-z0-9])',
+    ]
+    """List of regex patterns to extract build targets from component paths."""
+
+    extend_component_target_regexes: t.List[str] = []
+    """Additional target extraction regex patterns to extend the default list."""
+
     component_ignored_file_extensions: t.List[str] = [
         '.md',
         '.rst',
@@ -658,6 +667,14 @@ class CiSettings(BaseSettings):
         :returns: Set of compiled regex patterns
         """
         return {re.compile(regex) for regex in self.component_mapping_exclude_regexes}
+
+    @property
+    def all_component_target_regexes(self) -> t.Set[re.Pattern]:
+        """Get all component target regexes as compiled pattern objects.
+
+        :returns: Set of compiled regex patterns
+        """
+        return {re.compile(regex) for regex in self.component_target_regexes + self.extend_component_target_regexes}
 
     def get_modified_components(self, modified_files: t.Iterable[str]) -> t.Set[str]:
         """Get the set of components that have been modified based on the provided files.

--- a/idf_ci/settings.py
+++ b/idf_ci/settings.py
@@ -557,6 +557,9 @@ class CiSettings(BaseSettings):
     filter_non_test_related_apps_by_modified_files: bool = False
     """Whether to keep only directly modified non-test apps when modified files are provided."""
 
+    filter_apps_by_component_target: bool = False
+    """Filter apps by the component's target."""
+
     extra_default_build_targets: t.List[str] = []
     """Additional build targets to include by default."""
 

--- a/tests/test_component_targets.py
+++ b/tests/test_component_targets.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
+import os
 
 import pytest
 from esp_bool_parser import constants as bool_parser_constants
 
 from idf_ci.filters import component_targets as ct
+from idf_ci.settings import CiSettings
 
 
 @pytest.fixture(autouse=True)
@@ -24,38 +26,171 @@ def patched_all_targets():
         importlib.reload(ct)
 
 
-def test_component_targets_from_files_detects_targets_and_collapses_nested_folders():
-    modified_files = (
-        'components/foo/test_apps/esp32/main.c',
-        'components/foo/test_apps/esp32/subdir/extra.c',
-        'components/foo/test_apps/esp32s2/main.c',
-        'components/bar/test_apps/esp32c3/main.c',
-        'README.md',
-        '',
-        None,
+def _patch_settings(monkeypatch, **kwargs):
+    monkeypatch.setattr(ct, 'get_ci_settings', lambda: CiSettings(**kwargs))
+    ct.component_targets_from_files.cache_clear()
+
+
+@pytest.mark.parametrize(
+    'config_kwargs,modified_files,expected,make_absolute',
+    [
+        pytest.param(
+            {},
+            (
+                'components/foo/esp32/main.c',
+                'components/foo/esp32/subdir/extra.c',
+                'components/foo/esp32s2/main.c',
+                'components/bar/esp32c3/main.c',
+                'components/bar/esp32c3/sub/ignored.c',
+                'components/foo/test_apps/esp32/main.c',
+                'components/bar/test_apps/esp32/main.c',
+                'README.md',
+                '',
+                None,
+            ),
+            {
+                'bar': ['esp32c3'],
+                'foo': ['esp32', 'esp32s2'],
+            },
+            False,
+            id='default-targets-collapse-nested-and-ignore-excluded',
+        ),
+        pytest.param(
+            {},
+            ('components/foo/test_apps/esp32/main.c',),
+            {},
+            False,
+            id='excluded-paths-only',
+        ),
+        pytest.param(
+            {},
+            (
+                'components/foo/test_apps/esp32/main.c',
+                'components/foo/esp32s2/main.c',
+                'components/bar/test_apps/esp32c3/main.c',
+            ),
+            {
+                'foo': ['esp32s2'],
+            },
+            False,
+            id='excluded-and-usual-paths-mixed',
+        ),
+        pytest.param(
+            {},
+            (
+                'components/foo/Kconfig',
+                'components/foo/test_apps/esp32/main.c',
+                'components/bar',
+            ),
+            {
+                'bar': ['all'],
+                'foo': ['all'],
+            },
+            False,
+            id='component-root-changes-return-all',
+        ),
+        pytest.param(
+            {},
+            (
+                'components/foo/esp32/main.c',
+                'components/foo/esp32s2/main.c',
+            ),
+            {
+                'foo': ['esp32', 'esp32s2'],
+            },
+            True,
+            id='absolute-path-inputs',
+        ),
+        pytest.param(
+            {
+                'extend_component_mapping_regexes': [
+                    '/vendor_components/(.+?)/',
+                ],
+            },
+            (
+                'common_components/esp_common/esp32/main.c',
+                'vendor_components/vendor_wifi/esp32s2/main.c',
+                'vendor_components/vendor_wifi/esp32s2/sub/extra.c',
+            ),
+            {
+                'esp_common': ['esp32'],
+                'vendor_wifi': ['esp32s2'],
+            },
+            False,
+            id='additional-component-mapping-roots',
+        ),
+        pytest.param(
+            {
+                'component_target_regexes': [
+                    r'/targets/(linux|qemu)/',
+                ],
+            },
+            (
+                'components/foo/targets/linux/main.c',
+                'components/foo/targets/qemu/sub/extra.c',
+            ),
+            {
+                'foo': ['linux', 'qemu'],
+            },
+            False,
+            id='configured-target-regexes',
+        ),
+    ],
+)
+def test_component_targets_from_files_examples(monkeypatch, config_kwargs, modified_files, expected, make_absolute):
+    _patch_settings(monkeypatch, **config_kwargs)
+
+    if make_absolute:
+        modified_files = tuple(
+            os.path.abspath(path) if isinstance(path, str) and path else path for path in modified_files
+        )
+
+    assert ct.component_targets_from_files(modified_files) == expected
+
+
+def test_component_mapping_for_path_uses_all_component_mapping_regexes(monkeypatch):
+    _patch_settings(
+        monkeypatch,
+        extend_component_mapping_regexes=[
+            '/vendor_components/(.+?)/',
+        ],
     )
 
-    assert ct.component_targets_from_files(modified_files) == {
-        'bar': ['esp32c3'],
-        'foo': ['esp32', 'esp32s2'],
-    }
+    assert ct._component_mapping_for_path('components/foo/esp32/main.c') == (
+        'foo',
+        'components/foo',
+        'components/foo/esp32/main.c',
+    )
+    assert ct._component_mapping_for_path('common_components/esp_common/test.c') == (
+        'esp_common',
+        'common_components/esp_common',
+        'common_components/esp_common/test.c',
+    )
+    assert ct._component_mapping_for_path('vendor_components/vendor_wifi/esp32/main.c') == (
+        'vendor_wifi',
+        'vendor_components/vendor_wifi',
+        'vendor_components/vendor_wifi/esp32/main.c',
+    )
+    assert ct._component_mapping_for_path('README.md') is None
 
 
-def test_component_targets_from_files_returns_all_for_component_root_changes():
-    modified_files = (
-        'components/foo/Kconfig',
-        'components/foo/test_apps/esp32/main.c',
-        'components/bar',
+def test_extract_targets_uses_configured_regexes(monkeypatch):
+    _patch_settings(
+        monkeypatch,
+        component_target_regexes=[
+            r'/targets/(linux|qemu)/',
+        ],
     )
 
-    assert ct.component_targets_from_files(modified_files) == {
-        'bar': ['all'],
-        'foo': ['all'],
-    }
+    assert ct.extract_targets('components/foo/targets/linux/main.c') == {'linux'}
+    assert ct.extract_targets('components/foo/targets/linux/targets/qemu/main.c') == {'linux', 'qemu'}
+    assert ct.extract_targets('components/foo/esp32/main.c') == set()
 
 
 def test_combined_targets_for_components_only_uses_requested_components():
     modified_files = (
+        'components/foo/esp32/main.c',
+        'components/foo/esp32s2/main.c',
         'components/foo/test_apps/esp32/main.c',
         'components/foo/test_apps/esp32s2/main.c',
         'components/bar/Kconfig',
@@ -71,14 +206,29 @@ def test_combined_targets_for_components_only_uses_requested_components():
     'modified_files,check_components,current_target,expected',
     [
         (('components/foo/test_apps/esp32/main.c',), ['foo'], 'esp32', False),
-        (('components/foo/test_apps/esp32/main.c',), ['foo'], 'esp32c3', True),
+        (('components/foo/test_apps/esp32/main.c',), ['foo'], 'esp32c3', False),
         (('components/foo/Kconfig',), ['foo'], 'esp32c3', False),
         (('components/foo/test_apps/esp32/main.c',), ['missing'], 'esp32c3', False),
-        (('components/foo/test_apps/esp32/main.c',), [], 'esp32c3', True),
+        (('components/foo/test_apps/esp32/main.c',), [], 'esp32c3', False),
         (('components/foo/test_apps/esp32/main.c', 'components/foo/test_apps/another/main.c'), [], 'esp32c3', False),
         ((), [], 'esp32c3', False),
         (('a/b/c',), [], 'esp32c3', False),
         (('a/b/c',), ['soc'], 'esp32c3', False),
+        (('components/foo/esp32/main.c',), ['foo'], 'esp32', False),
+        (('components/foo/esp32/main.c', 'components/foo/esp32s2/main.c'), ['foo'], 'esp32s2', False),
+        (('components/foo/esp32/main.c', 'components/bar/esp32s2/main.c'), [], 'esp32s2', False),
+        (('components/foo/esp32/main.c', 'components/bar/Kconfig'), ['bar'], 'esp32c3', False),
+        (('common_components/esp_common/esp32/main.c',), ['esp_common'], 'esp32', False),
+        (('components/foo/esp32/main.c',), ['foo'], 'esp32c3', True),
+        (('components/foo/esp32/main.c',), [], 'esp32c3', True),
+        (('components/foo/esp32/main.c', 'components/foo/esp32/subdir/extra.c'), ['foo'], 'esp32s2', True),
+        (('components/foo/esp32/main.c', 'components/foo/esp32s2/main.c'), ['foo'], 'esp32c3', True),
+        (('components/foo/esp32/main.c', 'components/bar/esp32s2/main.c'), [], 'esp32c3', True),
+        (('components/foo/esp32/main.c', 'components/bar/esp32s2/main.c'), ['foo'], 'esp32s2', True),
+        (('components/foo/esp32/main.c', 'components/bar/esp32s2/main.c'), ['bar'], 'esp32', True),
+        (('components/foo/esp32/main.c', 'components/bar/Kconfig'), ['foo'], 'esp32c3', True),
+        (('components/foo/esp32/main.c', 'a/b/c'), [], 'esp32c3', True),
+        (('common_components/esp_common/esp32/main.c',), ['esp_common'], 'esp32c3', True),
     ],
 )
 def test_should_skip_build_for_components(modified_files, check_components, current_target, expected):

--- a/tests/test_component_targets.py
+++ b/tests/test_component_targets.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+
+import pytest
+from esp_bool_parser import constants as bool_parser_constants
+
+from idf_ci.filters import component_targets as ct
+
+
+@pytest.fixture(autouse=True)
+def patched_all_targets():
+    original_targets = bool_parser_constants.ALL_TARGETS
+    bool_parser_constants.ALL_TARGETS = ['esp32', 'esp32s2', 'esp32c3']
+    importlib.reload(ct)
+    ct.component_targets_from_files.cache_clear()
+
+    try:
+        yield
+    finally:
+        ct.component_targets_from_files.cache_clear()
+        bool_parser_constants.ALL_TARGETS = original_targets
+        importlib.reload(ct)
+
+
+def test_component_targets_from_files_detects_targets_and_collapses_nested_folders():
+    modified_files = (
+        'components/foo/test_apps/esp32/main.c',
+        'components/foo/test_apps/esp32/subdir/extra.c',
+        'components/foo/test_apps/esp32s2/main.c',
+        'components/bar/test_apps/esp32c3/main.c',
+        'README.md',
+        '',
+        None,
+    )
+
+    assert ct.component_targets_from_files(modified_files) == {
+        'bar': ['esp32c3'],
+        'foo': ['esp32', 'esp32s2'],
+    }
+
+
+def test_component_targets_from_files_returns_all_for_component_root_changes():
+    modified_files = (
+        'components/foo/Kconfig',
+        'components/foo/test_apps/esp32/main.c',
+        'components/bar',
+    )
+
+    assert ct.component_targets_from_files(modified_files) == {
+        'bar': ['all'],
+        'foo': ['all'],
+    }
+
+
+def test_combined_targets_for_components_only_uses_requested_components():
+    modified_files = (
+        'components/foo/test_apps/esp32/main.c',
+        'components/foo/test_apps/esp32s2/main.c',
+        'components/bar/Kconfig',
+    )
+
+    assert ct.combined_targets_for_components(modified_files, ['foo']) == ['esp32', 'esp32s2']
+    assert ct.combined_targets_for_components(modified_files, ['bar']) == ['all']
+    assert ct.combined_targets_for_components(modified_files, ['missing']) == []
+    assert ct.combined_targets_for_components(modified_files, []) == ['all']
+
+
+@pytest.mark.parametrize(
+    'modified_files,check_components,current_target,expected',
+    [
+        (('components/foo/test_apps/esp32/main.c',), ['foo'], 'esp32', False),
+        (('components/foo/test_apps/esp32/main.c',), ['foo'], 'esp32c3', True),
+        (('components/foo/Kconfig',), ['foo'], 'esp32c3', False),
+        (('components/foo/test_apps/esp32/main.c',), ['missing'], 'esp32c3', False),
+        (('components/foo/test_apps/esp32/main.c',), [], 'esp32c3', True),
+        (('components/foo/test_apps/esp32/main.c', 'components/foo/test_apps/another/main.c'), [], 'esp32c3', False),
+        ((), [], 'esp32c3', False),
+        (('a/b/c',), [], 'esp32c3', False),
+        (('a/b/c',), ['soc'], 'esp32c3', False),
+    ],
+)
+def test_should_skip_build_for_components(modified_files, check_components, current_target, expected):
+    assert ct.should_skip_build_for_components(modified_files, check_components, current_target) is expected

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,6 +5,7 @@ import os
 import re
 
 import pytest
+from esp_bool_parser.constants import ALL_TARGETS
 
 from idf_ci.cli import click_cli
 from idf_ci.settings import CiSettings, DeprecatedConfigWarning
@@ -41,6 +42,13 @@ def test_default_component_mapping_regexes():
         '/common_components/(.+?)/',
     ]
     assert CiSettings().component_mapping_regexes == expected_regexes
+
+
+def test_default_component_target_regexes():
+    expected_regexes = [
+        r'(?<![a-z0-9])(' + '|'.join(sorted(ALL_TARGETS, key=len, reverse=True)) + r')(?![a-z0-9])',
+    ]
+    assert CiSettings().component_target_regexes == expected_regexes
 
 
 def test_default_component_ignored_file_extensions():
@@ -125,6 +133,24 @@ def test_all_component_mapping_regexes():
         if '/components/(.+)/' in pattern.pattern:
             assert match is not None
             assert match.group(1) == 'test_component'
+
+
+def test_all_component_target_regexes():
+    settings = CiSettings(
+        extend_component_target_regexes=[
+            r'(?<![a-z0-9])(linux)(?![a-z0-9])',
+        ]
+    )
+    patterns = settings.all_component_target_regexes
+    assert len(patterns) == 2
+
+    default_pattern = next(pattern for pattern in patterns if 'esp32' in pattern.pattern)
+    assert default_pattern.search('/components/test/esp32/main.c')
+
+    extended_pattern = next(pattern for pattern in patterns if 'linux' in pattern.pattern)
+    match = extended_pattern.search('/components/test/linux/main.c')
+    assert match is not None
+    assert match.group(1) == 'linux'
 
 
 def test_component_mapping_with_absolute_paths():


### PR DESCRIPTION
## Description

This PR introduces a feature to filter apps based on component's targets.

Some components include targets in their paths, for example: `components/soc/esp32`. In such cases, we should build the app only for `esp32`, not for other targets.

There are a few scenarios to consider:

* If components like:

  * `components/soc/esp32`
  * `components/soc/foo` 
  are modified, and for `soc/foo` no specific target can be determined from a component path, it means we should build for all targets.

After processing the modified files, we create a dictionary that maps components to targets. Using this mapping, we can filter apps.

Apps contain dependent components, and these dependencies already reference the components. Therefore, we can filter apps based on our dictionary.

* If none of the app’s dependent components are in the dictionary, we should not filter the app, as it will be handled by other filters.
* If an app does not define dependent components, we can assume it depends on all components, since most components are included implicitly.

For example, if a merge request includes changes related to `esp32`, it makes sense to filter apps based on that target.


## Test cases

```
    'modified_files,check_components,current_target,expected',
    [
        (('components/foo/test_apps/esp32/main.c',), ['foo'], 'esp32', False),
        (('components/foo/test_apps/esp32/main.c',), ['foo'], 'esp32c3', True),
        (('components/foo/Kconfig',), ['foo'], 'esp32c3', False),
        (('components/foo/test_apps/esp32/main.c',), ['missing'], 'esp32c3', False),
        (('components/foo/test_apps/esp32/main.c',), [], 'esp32c3', True),
        (('components/foo/test_apps/esp32/main.c','components/foo/test_apps/another/main.c'), [], 'esp32c3', False),
        ((), [], 'esp32c3', False),
        (('a/b/c',), [], 'esp32c3', False),
        (('a/b/c',), ['soc'], 'esp32c3', False),
    ],
```