### PR TITLE
fix(gitlab): propagate job_name_suffix to test-child-pipeline generation (CII-213)

### DIFF
--- a/idf_ci/settings.py
+++ b/idf_ci/settings.py
@@ -370,6 +370,7 @@ generate_test_child_pipeline{{ settings.gitlab.build_pipeline.job_name_suffix }}
       - "{{ settings.gitlab.test_pipeline.yaml_filename }}"
   script:
     - idf-ci
+      --config 'gitlab.build_pipeline.job_name_suffix="{{ settings.gitlab.build_pipeline.job_name_suffix }}"'
       --config 'gitlab.test_pipeline.job_image="{{ settings.gitlab.test_pipeline.job_image }}"'
       gitlab test-child-pipeline
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
The generate_test_child_pipeline job runs a separate `idf-ci gitlab test-child-pipeline` call that did not receive build_pipeline.job_name_suffix. As a result the test jobs' `needs` pointed to an unsuffixed generate_test_child_pipeline job that does not exist, failing with missing_dependency_failure whenever a job suffix was set.

Pass build_pipeline.job_name_suffix to that call so the generated test jobs reference the correct suffixed job name.
